### PR TITLE
Prevent list model roles getting out of sync

### DIFF
--- a/jsonlistmodel.cpp
+++ b/jsonlistmodel.cpp
@@ -150,7 +150,6 @@ void JsonListModel::clear()
     int originalSize = m_keys.length();
     m_keys.clear();
     m_items.clear();
-    m_roles.clear();
     m_lock->unlock();
 
    beginRemoveRows(QModelIndex(), 0, originalSize);

--- a/qpm.json
+++ b/qpm.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Cutehacks/gel.git"
   },
   "version": {
-    "label": "0.2.1"
+    "label": "0.2.2"
   },
   "dependencies": [
   ],


### PR DESCRIPTION
A bug is triggered when clearing a JSON list model and readding data
with different properties, causing the order of the roles to change.

QML list views will still look for existing properties at their previous
role indexes.

The QAbstractItemModel documentation states "Modifying the role names
after the model has been set may result in undefined behaviour."

Since there's also no way to notify that the abstract item models roles
have changed, the safest option is to not reorder existing roles, but
just add new roles at the end of the list.

Bump to version 0.2.2.
