### PR TITLE
Make updateModel() a public slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,15 @@ function should return true for items that should be included; otherwise false.
 Return the jsobject at the index specified by the number. If Collection is sorted or filtered, then
 the index here refers to the index in the Collection *not* the JsonListModel.
 
+### reSort() : function
+
+Trigger sorting the collection again.
+
+**NOTE** Calling this function is *not* required if data within the model itself has changed
+(re-sorting will be conducted automatically in that case). You want to call this function if
+external data has been updated, e.g. you sort a model by distance and the current position
+of the user has changed.
+
 ### descendingSort : property bool: false
 
 Indicates if the role based sorting is sorted in ascending or descending order.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Return the jsobject that has the id specified by 'id'.
 
 ## Collection
 
-An item for sorting an filtering a JsonListModel. The Collection itself does not
+An item for sorting and filtering a JsonListModel. The Collection itself does not
 store any data, but rather proxies the data stored inside the source model.
 
 ### model : JsonListModel

--- a/collection.cpp
+++ b/collection.cpp
@@ -115,3 +115,8 @@ QJSValue Collection::at(int row) const
     return jsonModel->at(source.row());
 }
 
+void Collection::reSort()
+{
+    sort(0);
+}
+

--- a/collection.h
+++ b/collection.h
@@ -26,6 +26,8 @@ public:
 
     Q_INVOKABLE QJSValue at(int) const;
 
+    Q_INVOKABLE void reSort();
+
     inline bool caseSensitiveSort() const
     {
         return sortCaseSensitivity() == Qt::CaseSensitive;


### PR DESCRIPTION
Being able to call updateModel() directly
from QML/from outside may be helpful sometimes,
e.g. if you sort a collection by distance and
the current position changes. You don't want
to change the model in that situation, you
don't want to change your filter criteria,
simply the model should be updated.
