### PR TITLE
Revert "Make updateModel() a public slot"

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,15 +164,6 @@ function should return true for items that should be included; otherwise false.
 Return the jsobject at the index specified by the number. If Collection is sorted or filtered, then
 the index here refers to the index in the Collection *not* the JsonListModel.
 
-### reSort() : function
-
-Trigger sorting the collection again.
-
-**NOTE** Calling this function is *not* required if data within the model itself has changed
-(re-sorting will be conducted automatically in that case). You want to call this function if
-external data has been updated, e.g. you sort a model by distance and the current position
-of the user has changed.
-
 ### descendingSort : property bool: false
 
 Indicates if the role based sorting is sorted in ascending or descending order.

--- a/collection.cpp
+++ b/collection.cpp
@@ -115,8 +115,3 @@ QJSValue Collection::at(int row) const
     return jsonModel->at(source.row());
 }
 
-void Collection::reSort()
-{
-    sort(0);
-}
-

--- a/collection.h
+++ b/collection.h
@@ -26,8 +26,6 @@ public:
 
     Q_INVOKABLE QJSValue at(int) const;
 
-    Q_INVOKABLE void reSort();
-
     inline bool caseSensitiveSort() const
     {
         return sortCaseSensitivity() == Qt::CaseSensitive;


### PR DESCRIPTION
Reverts Cutehacks/gel#7

This is a bit embarrassing: Unfortunately, I have to suggest reverting my changes. :/ 

As the Jolla currently does not support fake locations, it is hard for me to properly test my code (this is my excuse ;)). It was only later that I found out that just calling `sort(0)` doesn't actually have the desired effect, because of [this line](http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qsortfilterproxymodel.cpp#n2277) in `QSortFilterProxyModel`:

```
    if (d->dynamic_sortfilter && d->proxy_sort_column == column && d->sort_order == order)
        return;
```

However, invoking the `invalidate()` slot, **does** cause the proxy model being sorted again.
Unfortunately, this seems to be doing too much: When I call it `onPositionChanged`, it completely resets my list and jumps to the top of the list. Furthermore, if I show one item of that list (in the detailed view), the index is updated `onPositionChanged`, too, and suddenly another item gets shown. Hence, I have to find another solution for dynamic sorting. But in the meantime, I'll probably just stick with a menu item "Update sorting", which invokes `invalidate()`, and I have to leave the dynamic sorting aside for the moment (as it seems to be a slightly bigger deal ATM). 

Anyway, I am very sorry for the inconvenience. :(
