### PR TITLE
Only use qUtf8Printable for Qt versions >= 5.4,

### DIFF
--- a/jsonlistmodel.cpp
+++ b/jsonlistmodel.cpp
@@ -114,7 +114,7 @@ int JsonListModel::addItem(const QJSValue &item)
         id = item.toString();
     } else if (item.isObject()) {
         if (!item.hasProperty(m_idAttribute)) {
-            qWarning("Object does not have a %s property", qUtf8Printable(m_idAttribute));
+            qWarning("Object does not have a %s property", qPrintable(m_idAttribute));
             return row;
         }
         id = item.property(m_idAttribute).toString();


### PR DESCRIPTION
as this function was first added in this version of Qt.
Use qPrintable for smaller Qt versions.

Fixes #11