### PR TITLE
Add a 'reFilter()' function to the Collection QML object,

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,13 @@ Trigger sorting the collection again.
 external data has been updated, e.g. you sort a model by distance and the current position
 of the user has changed.
 
+### reFilter() : function
+
+Trigger refiltering the collection.
+
+**NOTE** Same as reSort(), this function is not required if the data within the model itself
+has changed.
+
 ### descendingSort : property bool: false
 
 Indicates if the role based sorting is sorted in ascending or descending order.

--- a/collection.cpp
+++ b/collection.cpp
@@ -122,5 +122,10 @@ void Collection::reSort()
     sort(0);
 }
 
+void Collection::reFilter()
+{
+    invalidateFilter();
+}
+
 } } }
 

--- a/collection.h
+++ b/collection.h
@@ -30,6 +30,7 @@ public:
     Q_INVOKABLE QJSValue at(int) const;
 
     Q_INVOKABLE void reSort();
+    Q_INVOKABLE void reFilter();
 
     inline bool caseSensitiveSort() const
     {


### PR DESCRIPTION
which allows its user manually triggering
a re-filtering of the collection (in the same way
reSort() does for sorting).