### PR TITLE
Add a workaround to Collection::reSort()

### DIFF
--- a/collection.cpp
+++ b/collection.cpp
@@ -119,8 +119,16 @@ QJSValue Collection::at(int row) const
 
 void Collection::reSort()
 {
-    sort(0);
+    if (dynamicSortFilter())
+    {
+        // Workaround: If dynamic_sortfilter == true, sort(0) will not (always)
+        // result in d->sort() being called, but setDynamicSortFilter(true) will.
+        setDynamicSortFilter(true);
+    }
+    else
+    {
+        sort(0);
+    }
 }
 
 } } }
-


### PR DESCRIPTION
for the case that dynamic_sortfilter == true, because in
that case d->sort() will not be called. See
<http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qsortfilterproxymodel.cpp#n2222>:

>   void QSortFilterProxyModel::sort(int column, Qt::SortOrder order)
>   {
>       Q_D(QSortFilterProxyModel);
>       if (d->dynamic_sortfilter && d->proxy_sort_column == column &&
>           d->sort_order == order)
>           return;

However, setDynamicSortFilter(true) always calls d->sort(), see
<http://code.qt.io/cgit/qt/qtbase.git/tree/src/corelib/itemmodels/qsortfilterproxymodel.cpp#n2455>:

>   void QSortFilterProxyModel::setDynamicSortFilter(bool enable)
>   {
>       Q_D(QSortFilterProxyModel);
>       d->dynamic_sortfilter = enable;
>       if (enable)
>           d->sort();
>   }

Unfortunately, we have to use this workaround and cannot simply directly
call d->sort() in Collection::reSort(), because QSortFilterProxyModelPrivate
is not accessible even if we activated the QtCore-private module.

Fixes #9 

PS: This time I did thoroughly test the new code I am suggesting to be merged ;)
(and it works fine for me).